### PR TITLE
Type erase `RandomAccessDisk` generic parameter everywhere.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-###Changed
+### Changed
 
-###Removed
+- `Hyperbee` no longer takes a generic parameter with `CoreMem` bound.
+
+### Removed
+
+- `CoreMem` trait and all usage of it.
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ clib = ["tokio/rt-multi-thread", "dep:libc"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1.77"
 derive_builder = "0.12.0"
 futures-lite = "2.1.0"
 hypercore = "0.12.1"

--- a/release.toml
+++ b/release.toml
@@ -2,6 +2,6 @@ pre-release-replacements = [
   {file="CHANGELOG.md", search="Unreleased", replace="{{version}}"},
   {file="CHANGELOG.md", search="\\.\\.\\.HEAD", replace="...{{tag_name}}", exactly=1},
   {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}"},
-  {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n\n## [Unreleased] - ReleaseDate\n\n### Added\n\n###Changed\n\n###Removed\n\n", exactly=1},
+  {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n\n## [Unreleased] - ReleaseDate\n\n### Added\n\n ###Changed\n\n### Removed\n\n", exactly=1},
   {file="CHANGELOG.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/cowlicks/hyperbee/compare/{{tag_name}}...HEAD", exactly=1},
 ]

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -1,15 +1,17 @@
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
 
+use async_trait::async_trait;
 use derive_builder::Builder;
-use hypercore::{AppendOutcome, Hypercore};
+use hypercore::{AppendOutcome, Hypercore, Info};
 use prost::Message;
+use random_access_storage::RandomAccess;
 use tokio::sync::{Mutex, RwLock};
 use tracing::trace;
 
 use crate::{
     changes::Changes,
     messages::{Node as NodeSchema, YoloIndex},
-    BlockEntry, CoreMem, HyperbeeError, Shared,
+    BlockEntry, HyperbeeError, Shared,
 };
 
 #[derive(Builder, Debug)]
@@ -19,7 +21,29 @@ pub struct Blocks {
     #[builder(default)]
     // TODO make the cache smarter. Allow setting max size and strategy
     cache: Shared<BTreeMap<u64, Shared<BlockEntry>>>,
-    core: Arc<Mutex<Hypercore>>,
+    core: Arc<Mutex<dyn HypercoreAcces>>,
+}
+
+#[async_trait]
+pub trait HypercoreAcces: Debug + Send {
+    async fn _get(&mut self, index: u64) -> Result<Option<Vec<u8>>, HyperbeeError>;
+    fn _info(&self) -> Info;
+    async fn _append(&mut self, data: &[u8]) -> Result<AppendOutcome, HyperbeeError>;
+}
+
+#[async_trait]
+impl<M: RandomAccess + Debug + Send> HypercoreAcces for Hypercore<M> {
+    async fn _get(&mut self, index: u64) -> Result<Option<Vec<u8>>, HyperbeeError> {
+        Ok(self.get(index).await?)
+    }
+
+    fn _info(&self) -> Info {
+        self.info()
+    }
+
+    async fn _append(&mut self, data: &[u8]) -> Result<AppendOutcome, HyperbeeError> {
+        Ok(self.append(data).await?)
+    }
 }
 
 impl Blocks {
@@ -56,7 +80,7 @@ impl Blocks {
         seq: &u64,
         blocks: Shared<Self>,
     ) -> Result<Option<BlockEntry>, HyperbeeError> {
-        match self.core.lock().await.get(*seq).await? {
+        match self.core.lock().await._get(*seq).await? {
             Some(core_block) => {
                 let node = NodeSchema::decode(&core_block[..])?;
                 Ok(Some(BlockEntry::new(node, blocks)?))
@@ -66,11 +90,11 @@ impl Blocks {
     }
 
     pub async fn info(&self) -> hypercore::Info {
-        self.core.lock().await.info()
+        self.core.lock().await._info()
     }
 
     pub async fn append(&self, value: &[u8]) -> Result<AppendOutcome, HyperbeeError> {
-        Ok(self.core.lock().await.append(value).await?)
+        self.core.lock().await._append(value).await
     }
 
     #[tracing::instrument(skip(self, changes))]

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -15,14 +15,14 @@ use crate::{
 #[derive(Builder, Debug)]
 #[builder(pattern = "owned", derive(Debug))]
 /// Interface to the underlying Hypercore
-pub struct Blocks<M: CoreMem> {
+pub struct Blocks {
     #[builder(default)]
     // TODO make the cache smarter. Allow setting max size and strategy
     cache: Shared<BTreeMap<u64, Shared<BlockEntry>>>,
     core: Arc<Mutex<Hypercore>>,
 }
 
-impl<M: CoreMem> Blocks {
+impl Blocks {
     /// Get a BlockEntry for the given `seq`
     /// # Errors
     /// when the provided `seq` is not in the Hypercore

--- a/src/changes.rs
+++ b/src/changes.rs
@@ -3,7 +3,7 @@ use crate::{Child, CoreMem, SharedNode};
 #[derive(Debug, Default)]
 /// Structure to store in-progress changes to the [`Hyperbee`]
 /// NB: because of how hyperbee-js works, we need to distinguish between root/non-root nodes.
-pub(crate) struct Changes<M: CoreMem> {
+pub(crate) struct Changes {
     seq: u64,
     pub key: Vec<u8>,
     pub value: Option<Vec<u8>>,
@@ -11,7 +11,7 @@ pub(crate) struct Changes<M: CoreMem> {
     pub root: Option<SharedNode>,
 }
 
-impl<M: CoreMem> Changes {
+impl Changes {
     pub fn new(seq: u64, key: &[u8], value: Option<&[u8]>) -> Self {
         Self {
             seq,

--- a/src/changes.rs
+++ b/src/changes.rs
@@ -1,4 +1,4 @@
-use crate::{Child, CoreMem, SharedNode};
+use crate::{Child, SharedNode};
 
 #[derive(Debug, Default)]
 /// Structure to store in-progress changes to the [`Hyperbee`]

--- a/src/changes.rs
+++ b/src/changes.rs
@@ -7,11 +7,11 @@ pub(crate) struct Changes<M: CoreMem> {
     seq: u64,
     pub key: Vec<u8>,
     pub value: Option<Vec<u8>>,
-    pub nodes: Vec<SharedNode<M>>,
-    pub root: Option<SharedNode<M>>,
+    pub nodes: Vec<SharedNode>,
+    pub root: Option<SharedNode>,
 }
 
-impl<M: CoreMem> Changes<M> {
+impl<M: CoreMem> Changes {
     pub fn new(seq: u64, key: &[u8], value: Option<&[u8]>) -> Self {
         Self {
             seq,
@@ -23,7 +23,7 @@ impl<M: CoreMem> Changes<M> {
     }
 
     /// Add a node that's changed. Returns the's stored node's reference
-    pub fn add_node(&mut self, node: SharedNode<M>) -> Child<M> {
+    pub fn add_node(&mut self, node: SharedNode) -> Child {
         self.nodes.push(node.clone());
         let offset: u64 = self
             .nodes
@@ -34,13 +34,13 @@ impl<M: CoreMem> Changes<M> {
     }
 
     /// Should only be used when [`Hyperbee::del`] causes a dangling root
-    pub fn overwrite_root(&mut self, root: SharedNode<M>) -> Child<M> {
+    pub fn overwrite_root(&mut self, root: SharedNode) -> Child {
         self.root = Some(root.clone());
         Child::new(self.seq, 0, Some(root))
     }
 
     /// Add changed root
-    pub fn add_root(&mut self, root: SharedNode<M>) -> Child<M> {
+    pub fn add_root(&mut self, root: SharedNode) -> Child {
         if self.root.is_some() {
             panic!("We should never be replacing a root on a changes");
         }
@@ -48,7 +48,7 @@ impl<M: CoreMem> Changes<M> {
     }
 
     /// adds a changed node and handles when the node should be used as the root
-    pub fn add_changed_node(&mut self, path_len: usize, node: SharedNode<M>) -> Child<M> {
+    pub fn add_changed_node(&mut self, path_len: usize, node: SharedNode) -> Child {
         if path_len == 0 {
             self.add_root(node)
         } else {

--- a/src/del.rs
+++ b/src/del.rs
@@ -26,7 +26,7 @@ impl Side {
     /// This is just:
     /// match self { Right => index + 1, Left => index - 1 }
     /// but with bounds checking
-    async fn get_donor_index<M: CoreMem>(
+    async fn get_donor_index(
         &self,
         father: SharedNode,
         deficient_index: usize,
@@ -59,7 +59,7 @@ impl Side {
         }
     }
 
-    async fn get_donor_key<M: CoreMem>(&self, donor: SharedNode) -> KeyValue {
+    async fn get_donor_key(&self, donor: SharedNode) -> KeyValue {
         match self {
             Right => donor.write().await.keys.remove(0),
             Left => donor
@@ -71,7 +71,7 @@ impl Side {
         }
     }
 
-    async fn get_donor_child<M: CoreMem>(&self, donor: SharedNode) -> Option<Child> {
+    async fn get_donor_child(&self, donor: SharedNode) -> Option<Child> {
         if donor.read().await.is_leaf().await {
             return None;
         }
@@ -89,7 +89,7 @@ impl Side {
         })
     }
 
-    async fn swap_donor_key_in_father<M: CoreMem>(
+    async fn swap_donor_key_in_father(
         &self,
         father: SharedNode,
         deficient_index: usize,
@@ -106,7 +106,7 @@ impl Side {
             .expect("one val removed in splice")
     }
 
-    async fn insert_donations_into_deficient_child<M: CoreMem>(
+    async fn insert_donations_into_deficient_child(
         &self,
         deficient_child: SharedNode,
         key: KeyValue,
@@ -142,7 +142,7 @@ impl Side {
         }
     }
 
-    async fn can_rotate<M: CoreMem>(
+    async fn can_rotate(
         &self,
         father: SharedNode,
         deficient_index: usize,
@@ -169,7 +169,7 @@ impl Side {
         }
     }
 
-    async fn rotate<M: CoreMem>(
+    async fn rotate(
         &self,
         father: SharedNode,
         deficient_index: usize,
@@ -206,7 +206,7 @@ impl Side {
         Ok(father)
     }
 
-    async fn maybe_rotate<M: CoreMem>(
+    async fn maybe_rotate(
         &self,
         father: SharedNode,
         deficient_index: usize,
@@ -226,7 +226,7 @@ impl Side {
     }
 
     #[tracing::instrument(skip(self, father, changes))]
-    async fn maybe_merge<M: CoreMem>(
+    async fn maybe_merge(
         &self,
         father: SharedNode,
         deficient_index: usize,
@@ -294,7 +294,7 @@ impl Side {
 
 #[tracing::instrument(skip(father, changes))]
 /// The orering of the kinds of repairs here is choosen to match the Hyperbee-js implementation
-async fn repair_one<M: CoreMem>(
+async fn repair_one(
     father: SharedNode,
     deficient_index: usize,
     order: usize,
@@ -328,7 +328,7 @@ async fn repair_one<M: CoreMem>(
 }
 /// must be given a path who's last element has a deficient child...
 #[tracing::instrument(skip(path, changes))]
-async fn repair<M: CoreMem>(
+async fn repair(
     path: &mut NodePath,
     order: usize,
     changes: &mut Changes,
@@ -374,7 +374,7 @@ fn cas_always_true(_kv: &KeyValueData) -> bool {
     true
 }
 
-impl<M: CoreMem> Tree {
+impl Tree {
     pub async fn del_compare_and_swap(
         &self,
         key: &[u8],

--- a/src/del.rs
+++ b/src/del.rs
@@ -1,6 +1,6 @@
 use crate::{
     changes::Changes, keys::InfiniteKeys, min_keys, nearest_node, put::propagate_changes_up_tree,
-    Child, CoreMem, HyperbeeError, KeyValue, KeyValueData, NodePath, SharedNode, Tree, MAX_KEYS,
+    Child, HyperbeeError, KeyValue, KeyValueData, NodePath, SharedNode, Tree, MAX_KEYS,
 };
 
 use Side::{Left, Right};
@@ -26,11 +26,7 @@ impl Side {
     /// This is just:
     /// match self { Right => index + 1, Left => index - 1 }
     /// but with bounds checking
-    async fn get_donor_index(
-        &self,
-        father: SharedNode,
-        deficient_index: usize,
-    ) -> Option<usize> {
+    async fn get_donor_index(&self, father: SharedNode, deficient_index: usize) -> Option<usize> {
         match *self {
             Left => {
                 if deficient_index == 0 {

--- a/src/hb.rs
+++ b/src/hb.rs
@@ -22,10 +22,10 @@ use super::{tree::Tree, CoreMem, Shared};
 #[derive(Debug, Builder)]
 #[builder(pattern = "owned", derive(Debug))]
 pub struct Hyperbee<M: CoreMem> {
-    tree: Shared<Tree<M>>,
+    tree: Shared<Tree>,
 }
 
-impl<M: CoreMem> Hyperbee<M> {
+impl<M: CoreMem> Hyperbee {
     /// The number of blocks in the hypercore.
     /// The first block is always the header block so:
     /// `version` would be the `seq` of the next block
@@ -109,7 +109,7 @@ impl<M: CoreMem> Hyperbee<M> {
     }
 
     /// Create a new tree with all it's operation's prefixed by the provided `prefix`.
-    pub fn sub(&self, prefix: &[u8], config: PrefixedConfig) -> Prefixed<M> {
+    pub fn sub(&self, prefix: &[u8], config: PrefixedConfig) -> Prefixed {
         Prefixed::new(prefix, self.tree.clone(), config)
     }
 

--- a/src/hb.rs
+++ b/src/hb.rs
@@ -13,7 +13,7 @@ use crate::{
     tree, KeyValueData,
 };
 
-use super::{tree::Tree, CoreMem, Shared};
+use super::{tree::Tree, Shared};
 
 /// An append only B-Tree built on [`Hypercore`](hypercore::Hypercore). It provides a key-value
 /// store API, with methods for [inserting](Hyperbee::put), [getting](Hyperbee::get), and
@@ -117,15 +117,10 @@ impl Hyperbee {
     pub async fn traverse<'a>(
         &self,
         conf: TraverseConfig,
-    ) -> Result<impl Stream<Item = KeyDataResult> + 'a, HyperbeeError>
-    where
-        M: 'a,
-    {
+    ) -> Result<impl Stream<Item = KeyDataResult> + 'a, HyperbeeError> {
         self.tree.read().await.traverse(conf).await
     }
-}
 
-impl Hyperbee<random_access_disk::RandomAccessDisk> {
     /// Helper for creating a Hyperbee
     /// # Panics
     /// when storage path is incorrect
@@ -136,18 +131,15 @@ impl Hyperbee<random_access_disk::RandomAccessDisk> {
     /// when Hyperbee fails to build
     pub async fn from_storage_dir<T: AsRef<Path>>(
         path_to_storage_dir: T,
-    ) -> Result<Hyperbee<random_access_disk::RandomAccessDisk>, HyperbeeError> {
+    ) -> Result<Hyperbee, HyperbeeError> {
         let tree = tree::Tree::from_storage_dir(path_to_storage_dir).await?;
         Ok(HyperbeeBuilder::default()
             .tree(Arc::new(RwLock::new(tree)))
             .build()?)
     }
-}
 
-impl Hyperbee<random_access_memory::RandomAccessMemory> {
     /// Helper for creating a Hyperbee in RAM
-    pub async fn from_ram(
-    ) -> Result<Hyperbee<random_access_memory::RandomAccessMemory>, HyperbeeError> {
+    pub async fn from_ram() -> Result<Hyperbee, HyperbeeError> {
         let tree = tree::Tree::from_ram().await?;
         Ok(HyperbeeBuilder::default()
             .tree(Arc::new(RwLock::new(tree)))

--- a/src/hb.rs
+++ b/src/hb.rs
@@ -21,11 +21,11 @@ use super::{tree::Tree, CoreMem, Shared};
 /// iterators](Hyperbee::traverse), and ["sub" B-Trees](Hyperbee::sub) for grouping related data.
 #[derive(Debug, Builder)]
 #[builder(pattern = "owned", derive(Debug))]
-pub struct Hyperbee<M: CoreMem> {
+pub struct Hyperbee {
     tree: Shared<Tree>,
 }
 
-impl<M: CoreMem> Hyperbee {
+impl Hyperbee {
     /// The number of blocks in the hypercore.
     /// The first block is always the header block so:
     /// `version` would be the `seq` of the next block

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ pub struct KeyValueData {
 
 #[derive(Debug)]
 /// Pointer used within a [`Node`] to reference to it's child nodes.
-struct Child<M: CoreMem> {
+struct Child {
     /// Index of the [`BlockEntry`] within the [`hypercore::Hypercore`] that contains the [`Node`]
     pub seq: u64,
     /// Index of the `Node` within the [`BlockEntry`] referenced by [`Child::seq`]
@@ -85,7 +85,7 @@ struct Child<M: CoreMem> {
 #[derive(Clone, Debug)]
 /// A "block" from a [`Hypercore`](hypercore::Hypercore) deserialized into the form used in
 /// Hyperbee
-struct BlockEntry<M: CoreMem> {
+struct BlockEntry {
     /// Pointers::new(NodeSchema::new(hypercore.get(seq)).index))
     nodes: Vec<SharedNode>,
     /// NodeSchema::new(hypercore.get(seq)).key
@@ -99,14 +99,14 @@ type SharedNode<T> = Shared<Node<T>>;
 type NodePath<T> = Vec<(SharedNode<T>, usize)>;
 
 #[derive(Debug)]
-struct Children<M: CoreMem> {
+struct Children {
     blocks: Shared<Blocks>,
     children: RwLock<Vec<Child>>,
 }
 
 /// A node of the B-Tree within the [`Hyperbee`]
 #[derive(Debug)]
-struct Node<M: CoreMem> {
+struct Node {
     keys: Vec<KeyValue>,
     children: Children,
     blocks: Shared<Blocks>,
@@ -118,7 +118,7 @@ impl KeyValue {
     }
 }
 
-impl<M: CoreMem> Child {
+impl Child {
     fn new(seq: u64, offset: u64, node: Option<SharedNode>) -> Self {
         Child {
             seq,
@@ -128,7 +128,7 @@ impl<M: CoreMem> Child {
     }
 }
 
-impl<M: CoreMem> Clone for Child {
+impl Clone for Child {
     fn clone(&self) -> Self {
         Self::new(self.seq, self.offset, self.cached_node.clone())
     }
@@ -157,7 +157,7 @@ fn make_node_vec<B: Buf, M: CoreMem>(
         .collect())
 }
 
-impl<M: CoreMem> Children {
+impl Children {
     fn new(blocks: Shared<Blocks>, children: Vec<Child>) -> Self {
         Self {
             blocks,
@@ -333,7 +333,7 @@ where
     }
 }
 
-impl<M: CoreMem> Node {
+impl Node {
     fn new(keys: Vec<KeyValue>, children: Vec<Child>, blocks: Shared<Blocks>) -> Self {
         Node {
             keys,
@@ -421,7 +421,7 @@ impl<M: CoreMem> Node {
     }
 }
 
-impl<M: CoreMem> BlockEntry {
+impl BlockEntry {
     fn new(entry: messages::Node, blocks: Shared<Blocks>) -> Result<Self, HyperbeeError> {
         Ok(BlockEntry {
             nodes: make_node_vec(&entry.index[..], blocks)?,

--- a/src/prefixed.rs
+++ b/src/prefixed.rs
@@ -36,7 +36,7 @@ impl Default for PrefixedConfig {
 pub struct Prefixed<M: CoreMem> {
     /// All keys inserted with [`Prefixed::put`] are prefixed with this value
     pub prefix: Vec<u8>,
-    tree: Shared<Tree<M>>,
+    tree: Shared<Tree>,
     conf: PrefixedConfig,
 }
 
@@ -48,8 +48,8 @@ macro_rules! with_key_prefix {
         &[&$self.prefix, &$self.conf.seperator, $key].concat()
     };
 }
-impl<M: CoreMem> Prefixed<M> {
-    pub(crate) fn new(prefix: &[u8], tree: Shared<Tree<M>>, conf: PrefixedConfig) -> Self {
+impl<M: CoreMem> Prefixed {
+    pub(crate) fn new(prefix: &[u8], tree: Shared<Tree>, conf: PrefixedConfig) -> Self {
         Self {
             prefix: prefix.to_vec(),
             tree,

--- a/src/prefixed.rs
+++ b/src/prefixed.rs
@@ -10,7 +10,7 @@ use crate::{
         LimitValue::{Finite, Infinite},
         TraverseConfig,
     },
-    CoreMem, KeyValueData, Shared, Tree,
+    KeyValueData, Shared, Tree,
 };
 
 pub static DEFAULT_PREFIXED_SEPERATOR: &[u8; 1] = b"\0";
@@ -128,10 +128,7 @@ impl Prefixed {
     pub async fn traverse<'a>(
         &self,
         conf: &TraverseConfig,
-    ) -> Result<impl Stream<Item = KeyDataResult> + 'a, HyperbeeError>
-    where
-        M: 'a,
-    {
+    ) -> Result<impl Stream<Item = KeyDataResult> + 'a, HyperbeeError> {
         let end_of_prefix = increment_bytes(&self.prefix);
 
         let (min_value, min_inclusive) = match &conf.min_value {

--- a/src/prefixed.rs
+++ b/src/prefixed.rs
@@ -33,7 +33,7 @@ impl Default for PrefixedConfig {
 
 /// A "sub" [`Hyperbee`](crate::Hyperbee), which can be used for grouping data. [`get`](Self::get), [`put`](Self::put), [`del`](Self::del), [`traverse`](Self::traverse) operations are automatically prefixed
 /// with [`Prefixed::prefix`] + [`PrefixedConfig::seperator`] where appropriate.
-pub struct Prefixed<M: CoreMem> {
+pub struct Prefixed {
     /// All keys inserted with [`Prefixed::put`] are prefixed with this value
     pub prefix: Vec<u8>,
     tree: Shared<Tree>,
@@ -48,7 +48,7 @@ macro_rules! with_key_prefix {
         &[&$self.prefix, &$self.conf.seperator, $key].concat()
     };
 }
-impl<M: CoreMem> Prefixed {
+impl Prefixed {
     pub(crate) fn new(prefix: &[u8], tree: Shared<Tree>, conf: PrefixedConfig) -> Self {
         Self {
             prefix: prefix.to_vec(),

--- a/src/put.rs
+++ b/src/put.rs
@@ -12,10 +12,10 @@ use crate::{
 /// root.
 #[tracing::instrument(skip(changes, path))]
 pub async fn propagate_changes_up_tree<M: CoreMem>(
-    mut changes: Changes<M>,
-    mut path: NodePath<M>,
-    new_child: Child<M>,
-) -> Changes<M> {
+    mut changes: Changes,
+    mut path: NodePath,
+    new_child: Child,
+) -> Changes {
     let mut cur_child = new_child;
     loop {
         // this should add children to node
@@ -29,11 +29,11 @@ pub async fn propagate_changes_up_tree<M: CoreMem>(
     }
 }
 
-impl<M: CoreMem> Node<M> {
+impl<M: CoreMem> Node {
     /// Split an overfilled node into two nodes and a a key.
     /// Returning: `(left_lower_node, middle_key, right_higher_node)`
     #[tracing::instrument(skip(self))]
-    async fn split(&mut self) -> (SharedNode<M>, KeyValue, SharedNode<M>) {
+    async fn split(&mut self) -> (SharedNode, KeyValue, SharedNode) {
         let key_median_index = self.keys.len() >> 1;
         let children_median_index = self.children.len().await >> 1;
         trace!(
@@ -64,7 +64,7 @@ impl<M: CoreMem> Node<M> {
 fn cas_always_true(_prev: Option<&KeyValueData>, _next: &KeyValueData) -> bool {
     true
 }
-impl<M: CoreMem> Tree<M> {
+impl<M: CoreMem> Tree {
     #[tracing::instrument(level = "trace", skip(self, cas), ret)]
     pub async fn put_compare_and_swap(
         &self,
@@ -76,9 +76,9 @@ impl<M: CoreMem> Tree<M> {
         let maybe_root = self.get_root(true).await?;
 
         let seq = self.version().await;
-        let mut changes: Changes<M> = Changes::new(seq, key, value);
+        let mut changes: Changes = Changes::new(seq, key, value);
         let mut cur_key = KeyValue::new(seq);
-        let mut children: Vec<Child<M>> = vec![];
+        let mut children: Vec<Child> = vec![];
 
         let new_key_data = KeyValueData {
             seq,

--- a/src/put.rs
+++ b/src/put.rs
@@ -4,8 +4,8 @@ use tokio::sync::RwLock;
 use tracing::trace;
 
 use crate::{
-    changes::Changes, nearest_node, Child, CoreMem, HyperbeeError, KeyValue, KeyValueData, Node,
-    NodePath, SharedNode, Tree, MAX_KEYS,
+    changes::Changes, nearest_node, Child, HyperbeeError, KeyValue, KeyValueData, Node, NodePath,
+    SharedNode, Tree, MAX_KEYS,
 };
 
 /// After making changes to a tree, this function updates parent references all the way to the

--- a/src/put.rs
+++ b/src/put.rs
@@ -11,7 +11,7 @@ use crate::{
 /// After making changes to a tree, this function updates parent references all the way to the
 /// root.
 #[tracing::instrument(skip(changes, path))]
-pub async fn propagate_changes_up_tree<M: CoreMem>(
+pub async fn propagate_changes_up_tree(
     mut changes: Changes,
     mut path: NodePath,
     new_child: Child,
@@ -29,7 +29,7 @@ pub async fn propagate_changes_up_tree<M: CoreMem>(
     }
 }
 
-impl<M: CoreMem> Node {
+impl Node {
     /// Split an overfilled node into two nodes and a a key.
     /// Returning: `(left_lower_node, middle_key, right_higher_node)`
     #[tracing::instrument(skip(self))]
@@ -64,7 +64,7 @@ impl<M: CoreMem> Node {
 fn cas_always_true(_prev: Option<&KeyValueData>, _next: &KeyValueData) -> bool {
     true
 }
-impl<M: CoreMem> Tree {
+impl Tree {
     #[tracing::instrument(level = "trace", skip(self, cas), ret)]
     pub async fn put_compare_and_swap(
         &self,

--- a/src/test.rs
+++ b/src/test.rs
@@ -43,7 +43,7 @@ fn interleave<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
 }
 
 #[async_recursion::async_recursion(?Send)]
-pub async fn check_node<M: CoreMem>(node: SharedNode<M>) {
+pub async fn check_node<M: CoreMem>(node: SharedNode) {
     let (n_keys, n_children) = {
         let r_node = node.read().await;
         (r_node.keys.len(), r_node.n_children().await)
@@ -107,7 +107,7 @@ pub async fn check_node<M: CoreMem>(node: SharedNode<M>) {
 /// * # keys + 1 == # children unless this is a leaf node
 /// * key's keys are between the nodes
 /// * all children respect these invariants
-pub async fn check_tree<M: CoreMem>(hb: Tree<M>) -> Result<Tree<M>, Box<dyn std::error::Error>> {
+pub async fn check_tree<M: CoreMem>(hb: Tree) -> Result<Tree, Box<dyn std::error::Error>> {
     let root = hb
         .get_root(false)
         .await?

--- a/src/test.rs
+++ b/src/test.rs
@@ -43,7 +43,7 @@ fn interleave<T: Clone>(a: &[T], b: &[T]) -> Vec<T> {
 }
 
 #[async_recursion::async_recursion(?Send)]
-pub async fn check_node<M: CoreMem>(node: SharedNode) {
+pub async fn check_node(node: SharedNode) {
     let (n_keys, n_children) = {
         let r_node = node.read().await;
         (r_node.keys.len(), r_node.n_children().await)
@@ -107,7 +107,7 @@ pub async fn check_node<M: CoreMem>(node: SharedNode) {
 /// * # keys + 1 == # children unless this is a leaf node
 /// * key's keys are between the nodes
 /// * all children respect these invariants
-pub async fn check_tree<M: CoreMem>(hb: Tree) -> Result<Tree, Box<dyn std::error::Error>> {
+pub async fn check_tree(hb: Tree) -> Result<Tree, Box<dyn std::error::Error>> {
     let root = hb
         .get_root(false)
         .await?

--- a/src/test.rs
+++ b/src/test.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use tokio::sync::OnceCell;
 
-use crate::{min_keys, CoreMem, SharedNode, Tree, MAX_KEYS};
+use crate::{min_keys, SharedNode, Tree, MAX_KEYS};
 
 #[allow(dead_code)]
 static INIT_LOG: OnceCell<()> = OnceCell::const_new();
@@ -147,7 +147,6 @@ macro_rules! hb_put {
     ( $contents:expr ) => {
         async move {
             use crate::{HyperbeeError, Tree};
-            use random_access_memory::RandomAccessMemory;
             let hb = Tree::from_ram().await?;
             let mut keys = vec![];
             for i in $contents {
@@ -156,7 +155,7 @@ macro_rules! hb_put {
                 let val: Option<&[u8]> = Some(&key);
                 hb.put(&&key, val).await?;
             }
-            Ok::<(Tree<RandomAccessMemory>, Vec<Vec<u8>>), HyperbeeError>((hb, keys))
+            Ok::<(Tree, Vec<Vec<u8>>), HyperbeeError>((hb, keys))
         }
     };
 }

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -140,7 +140,7 @@ impl Default for TraverseConfig {
 /// We don't care about the other bounding value here because that is handled within the Traverse
 /// logic.
 #[allow(clippy::collapsible_else_if)]
-async fn make_child_key_index_iter<M: CoreMem>(
+async fn make_child_key_index_iter(
     conf: TraverseConfig,
     node: SharedNode,
     n_keys: usize,
@@ -270,7 +270,7 @@ pub(crate) struct Traverse<'a, M: CoreMem> {
     child_stream: Option<Pin<Box<Traverse<'a, M>>>>,
 }
 
-impl<M: CoreMem> Traverse<'_, M> {
+impl Traverse<'_, M> {
     /// Create [`Traverse`] struct and to traverse the provided `node` based on the provided
     /// [`TraverseConfig`]
     pub fn new(note: SharedNode, config: TraverseConfig) -> Self {
@@ -289,14 +289,14 @@ impl<M: CoreMem> Traverse<'_, M> {
 }
 
 /// Return the tuple (number_of_keys, number_of_children) for the given node
-async fn get_n_keys_and_children<M: CoreMem>(node: SharedNode) -> (usize, usize) {
+async fn get_n_keys_and_children(node: SharedNode) -> (usize, usize) {
     (
         node.read().await.keys.len(),
         node.read().await.n_children().await,
     )
 }
 
-async fn get_key_and_value<M: CoreMem>(node: SharedNode, index: usize) -> KeyDataResult {
+async fn get_key_and_value(node: SharedNode, index: usize) -> KeyDataResult {
     node.read().await.get_key_value(index).await
 }
 
@@ -452,7 +452,7 @@ impl<'a, M: CoreMem + 'a> Stream for Traverse<'a, M> {
 static LEADER: &str = "\t";
 
 /// Print the keys of the provided node and it's descendents as a tree
-pub(crate) async fn print<M: CoreMem>(node: SharedNode) -> Result<String, HyperbeeError> {
+pub(crate) async fn print(node: SharedNode) -> Result<String, HyperbeeError> {
     let starting_height = node.read().await.height().await?;
     let mut out = "".to_string();
     let stream = Traverse::new(node, TraverseConfig::default());

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -23,10 +23,10 @@ use tokio::sync::{Mutex, RwLock};
 #[derive(Debug, Builder)]
 #[builder(pattern = "owned", derive(Debug))]
 pub struct Tree<M: CoreMem> {
-    pub blocks: Shared<Blocks<M>>,
+    pub blocks: Shared<Blocks>,
 }
 
-impl<M: CoreMem> Tree<M> {
+impl<M: CoreMem> Tree {
     /// The number of blocks in the hypercore.
     /// The first block is always the header block so:
     /// `version` would be the `seq` of the next block
@@ -39,7 +39,7 @@ impl<M: CoreMem> Tree<M> {
     pub(crate) async fn get_root(
         &self,
         ensure_header: bool,
-    ) -> Result<Option<Shared<Node<M>>>, HyperbeeError> {
+    ) -> Result<Option<Shared<Node>>, HyperbeeError> {
         let blocks = self.blocks.read().await;
         let version = self.version().await;
         if version <= 1 {
@@ -182,7 +182,7 @@ impl Tree<random_access_memory::RandomAccessMemory> {
     }
 }
 
-impl<M: CoreMem> Clone for Tree<M> {
+impl<M: CoreMem> Clone for Tree {
     fn clone(&self) -> Self {
         Self {
             blocks: self.blocks.clone(),

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -22,11 +22,11 @@ use tokio::sync::{Mutex, RwLock};
 /// library](https://docs.holepunch.to/building-blocks/hyperbee)
 #[derive(Debug, Builder)]
 #[builder(pattern = "owned", derive(Debug))]
-pub struct Tree<M: CoreMem> {
+pub struct Tree {
     pub blocks: Shared<Blocks>,
 }
 
-impl<M: CoreMem> Tree {
+impl Tree {
     /// The number of blocks in the hypercore.
     /// The first block is always the header block so:
     /// `version` would be the `seq` of the next block
@@ -182,7 +182,7 @@ impl Tree<random_access_memory::RandomAccessMemory> {
     }
 }
 
-impl<M: CoreMem> Clone for Tree {
+impl Clone for Tree {
     fn clone(&self) -> Self {
         Self {
             blocks: self.blocks.clone(),

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -9,7 +9,7 @@ use crate::{
     messages::{header::Metadata, Header},
     nearest_node,
     traverse::{self, KeyDataResult, Traverse, TraverseConfig},
-    CoreMem, Node, Shared, PROTOCOL,
+    Node, Shared, PROTOCOL,
 };
 use std::{
     path::{Path, PathBuf},
@@ -131,10 +131,7 @@ impl Tree {
     pub async fn traverse<'a>(
         &self,
         conf: TraverseConfig,
-    ) -> Result<impl Stream<Item = KeyDataResult> + 'a, HyperbeeError>
-    where
-        M: 'a,
-    {
+    ) -> Result<impl Stream<Item = KeyDataResult> + 'a, HyperbeeError> {
         let root = self
             .get_root(false)
             .await?
@@ -142,9 +139,7 @@ impl Tree {
         let stream = Traverse::new(root, conf);
         Ok(stream.map(move |kv_and_node| kv_and_node.0))
     }
-}
 
-impl Tree<random_access_disk::RandomAccessDisk> {
     /// Helper for creating a Hyperbee
     /// # Panics
     /// when storage path is incorrect
@@ -155,7 +150,7 @@ impl Tree<random_access_disk::RandomAccessDisk> {
     /// when Hyperbee fails to build
     pub async fn from_storage_dir<T: AsRef<Path>>(
         path_to_storage_dir: T,
-    ) -> Result<Tree<random_access_disk::RandomAccessDisk>, HyperbeeError> {
+    ) -> Result<Tree, HyperbeeError> {
         let p: PathBuf = path_to_storage_dir.as_ref().to_owned();
         let storage = Storage::new_disk(&p, false).await?;
         let hc = Arc::new(Mutex::new(HypercoreBuilder::new(storage).build().await?));
@@ -164,12 +159,8 @@ impl Tree<random_access_disk::RandomAccessDisk> {
             .blocks(Arc::new(RwLock::new(blocks)))
             .build()?)
     }
-}
-
-impl Tree<random_access_memory::RandomAccessMemory> {
     /// Helper for creating a Hyperbee in RAM
-    pub async fn from_ram() -> Result<Tree<random_access_memory::RandomAccessMemory>, HyperbeeError>
-    {
+    pub async fn from_ram() -> Result<Tree, HyperbeeError> {
         let hc = Arc::new(Mutex::new(
             HypercoreBuilder::new(Storage::new_memory().await?)
                 .build()


### PR DESCRIPTION
`RandomAccessDisk` is the bound on the generic parameter on `Hypercore`. It pervades the entire codebase, making `Hyperbee` require it as a generic parameter.

But to expose parts of `Hyperbee` over FFI with Uniffi. But this generic bound really complicates things.