### PR TITLE
WIP: bug in python tests 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,20 +40,23 @@ thiserror = "1.0.50"
 tokio = { version = "1.34.0", features = ["macros", "rt", "sync"] }
 tokio-stream = "0.1.14"
 tracing = "0.1.40"
-uniffi = { version = "0.26.1", features = ["cli"], optional = true }
+tracing-subscriber = {version = "0.3.18", features = ["env-filter"] }
+uniffi = { version = "0.28.1", features = ["cli", "tokio"], optional = true }
 
 [dependencies.hypercore]
-version = "0.13.0"
+default-features = false
+features = ["sparse", "tokio"]
+#version = "0.13.0"
+path = "../core"
 
 [build-dependencies]
 prost-build = "0.12.1"
-uniffi = { version = "0.26.1", features = ["build"], optional = true}
+uniffi = { version = "0.28.1", features = ["build"], optional = true}
 
 [dev-dependencies]
 tracing-subscriber = "0.3.18"
 tokio = { version = "1.34.0", features = ["rt-multi-thread"] }
 async-recursion = "1.0.5"
-random-access-memory = "3.0.0"
 once_cell = "1.19.0"
 tempfile = "3.10.0"
 serde_json = "1.0.114"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -109,9 +109,23 @@ async fn hyperbee_from_storage_dir(path_to_storage_dir: &str) -> Result<Hyperbee
     })
 }
 
+/// log current rt
+#[uniffi::export]
+fn try_current_rt() {
+    dbg!(tokio::runtime::Handle::try_current());
+}
+
 #[derive(Debug, uniffi::Object)]
 struct Prefixed {
     rust_prefixed: Shared<RustPrefixed>,
+}
+
+/// initialize logging
+#[uniffi::export]
+pub fn init_env_logs() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env()) // Reads `RUST_LOG` environment variable
+        .init();
 }
 
 #[uniffi::export]

--- a/src/hb.rs
+++ b/src/hb.rs
@@ -133,11 +133,13 @@ impl Hyperbee {
     pub async fn from_storage_dir<T: AsRef<Path>>(
         path_to_storage_dir: T,
     ) -> Result<Hyperbee, HyperbeeError> {
+        dbg!(tokio::runtime::Handle::try_current());
         Self::from_tree(Tree::from_storage_dir(path_to_storage_dir).await?)
     }
 
     /// Create a [`Hyperbee`] in RAM
     pub async fn from_ram() -> Result<Hyperbee, HyperbeeError> {
+        dbg!(tokio::runtime::Handle::try_current());
         Self::from_tree(Tree::from_ram().await?)
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -148,18 +148,29 @@ impl Tree {
     pub async fn from_storage_dir<T: AsRef<Path>>(
         path_to_storage_dir: T,
     ) -> Result<Tree, HyperbeeError> {
+        dbg!(tokio::runtime::Handle::try_current());
+        dbg!();
+        dbg!();
+        dbg!();
         let p: PathBuf = path_to_storage_dir.as_ref().to_owned();
+        dbg!();
         let storage = Storage::new_disk(&p, false).await?;
+        dbg!();
+        dbg!(tokio::runtime::Handle::current());
         let hc = Arc::new(Mutex::new(HypercoreBuilder::new(storage).build().await?));
+        dbg!();
         let blocks = BlocksBuilder::default().core(hc).build()?;
+        dbg!();
         Self::from_blocks(blocks)
     }
     pub async fn from_ram() -> Result<Tree, HyperbeeError> {
+        dbg!(tokio::runtime::Handle::try_current());
         let hc = Arc::new(Mutex::new(
             HypercoreBuilder::new(Storage::new_memory().await?)
                 .build()
                 .await?,
         ));
+        dbg!(tokio::runtime::Handle::try_current());
         let blocks = BlocksBuilder::default().core(hc).build()?;
         Self::from_blocks(blocks)
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -88,6 +88,7 @@ pub fn run_code(
     );
     let script_path = working_dir.path().join(script_file_name);
     let script_file = File::create(&script_path)?;
+    println!("{code}");
     write!(&script_file, "{}", &code)?;
 
     let working_dir_path = working_dir.path().display().to_string();
@@ -107,7 +108,10 @@ pub fn run_code(
     }
     let script_path_str = script_path.display().to_string();
     let cmd = build_command(&working_dir_path, &script_path_str);
-    check_cmd_output(Command::new("sh").arg("-c").arg(cmd).output()?)
+    let o = Command::new("sh").arg("-c").arg(cmd).output()?;
+    println!("OUT\n{}", String::from_utf8_lossy(&o.stdout));
+    println!("ERR\n{}", String::from_utf8_lossy(&o.stderr));
+    check_cmd_output(o)
 }
 
 pub fn run_make_from_with(dir: &str, arg: &str) -> Result<Output> {

--- a/tests/common/python/foo.py
+++ b/tests/common/python/foo.py
@@ -1,0 +1,29 @@
+import asyncio
+from target.hyperbee import *
+from target.hyperbee import uniffi_set_event_loop
+
+
+async def main():
+    import json
+    init_env_logs()
+    try_current_rt()
+    print(asyncio.get_running_loop())
+    uniffi_set_event_loop(asyncio.get_running_loop())
+    #hb = await hyperbee_from_storage_dir('./hbdir')
+    hb = await hyperbee_from_ram();
+    try_current_rt()
+    res = await hb.get(b'hello')
+    assert(res is None)
+        
+    try_current_rt()
+    hb = await hyperbee_from_storage_dir('./hbdir')
+    hb = await hyperbee_from_ram();
+    res = await hb.get(b'hello')
+
+    res = await hb.put(b'skipval', None)
+    res = await hb.get(b'skipval')
+    assert(res.value is None)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/tests/python.rs
+++ b/tests/python.rs
@@ -79,6 +79,8 @@ async fn optionals() -> Result<()> {
         "
 async def main():
     import json
+    init_env_logs()
+    try_current_rt()
     hb = await hyperbee_from_storage_dir('{}')
     res = await hb.get(b'hello')
     assert(res.value is None)


### PR DESCRIPTION
There is a weird bug, when hyperbee uses hypercore which is using tokio instead of async-std, then python tests that uses `hyperbee_from_storage_dir` there is an error. To reproduce  checkout the same branch with the same name with the hypercore and random-access-disk repository

The error is
```
Traceback (most recent call last):
  File "/tmp/.tmpFbU1Li/script.py", line 16, in <module>
    asyncio.run(main())
  File "/usr/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/tmp/.tmpFbU1Li/script.py", line 8, in main
    hb = await hyperbee_from_storage_dir('/tmp/.tmp0KajQ7')
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/.tmpFbU1Li/target/hyperbee.py", line 2055, in hyperbee_from_storage_dir
    return await _uniffi_rust_call_async(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/.tmpFbU1Li/target/hyperbee.py", line 2017, in _uniffi_rust_call_async
    _uniffi_rust_call_with_error(error_ffi_converter, ffi_complete, rust_future)
  File "/tmp/.tmpFbU1Li/target/hyperbee.py", line 295, in _uniffi_rust_call_with_error
    _uniffi_check_call_status(error_ffi_converter, call_status)
  File "/tmp/.tmpFbU1Li/target/hyperbee.py", line 315, in _uniffi_check_call_status
    raise InternalError(msg)
target.hyperbee.InternalError: there is no reactor running, must be called from the context of a Tokio 1.x runtime

```

It occurs in hypercore where it calls the `Storage::new_disk`